### PR TITLE
Suggestions for the testing chapter

### DIFF
--- a/_typos.toml
+++ b/_typos.toml
@@ -1,2 +1,5 @@
 [files]
 extend-exclude = ["*.svg", "**/*.svg", "target/**/*", "**/target/**/*"]
+
+[default.extend-words]
+ba = "ba"


### PR DESCRIPTION
1. Reorganize "5.1 Tests as Living Documentation" into smaller bits/advice
2. Add suggestion to use `mod` to organize unit tests
3. Some typo fixes
4. Add suggestion for `rstest` cases
5. Add note on `cargo nextest` + doctests