### PR TITLE
docs: add Rust 1.96 Copy+Iterator and assert_matches

### DIFF
--- a/book/chapter_01.md
+++ b/book/chapter_01.md
@@ -76,6 +76,7 @@ let new_num = increment(num); // `num` still usable after this point
 * All fields are `Copy` themselves.
 * The struct is `small`, up to 2 (maybe 3) words of memory or 24 bytes (each word is 64 bits/8bytes).
 * The struct **represents a “plain data object”**, without resourcing to ownership (no heap allocations. Example: `Vec` and `Strings`).
+* ❗**The type does not also implement `Iterator`.** Even if every field is `Copy`, never put `Copy` and `Iterator` on the same type (see [§1.5](#15-iterator-iter-vs-for)).
 
 ❗**Rust Arrays are stack allocated.** Which means they can be copied if their underlying type is `Copy`, but this will be allocated in the program stack which can easily become a stack overflow. More on [Chapter 3 - Stack vs Heap](https://github.com/apollographql/rust-best-practices/blob/main/book/chapter_03.md#33-stack-vs-heap-be-size-smart)
 
@@ -352,6 +353,7 @@ for value in vec.iter().enumerate()
 * Avoid needlessly collect/allocate of a collection (e.g. vector) just to throw it away later by some larger operation or by another iteration.
 * Prefer `iter` over `into_iter` unless you don't need the ownership of the collection.
 * Prefer `iter` over `into_iter` for collections that inner type implements `Copy`, e.g. `Vec<T: Copy>`.
+* **Never implement (or derive) both `Copy` and `Iterator` on the same type.** Copying an iterator and advancing one copy leaves the other untouched, which silently yields wrong results — it is a well-known footgun. The standard library hit exactly this: it is why `Range` historically could not be `Copy`, and why the new `core::range` types (stabilized in Rust 1.96) implement `IntoIterator` instead of `Iterator` so they *can* be `Copy`. If you need an iterator on a `Copy` type, implement `IntoIterator` and return a separate iterator struct.
 * For summing numbers prefer `.sum` over `.fold`. `.sum` is specialized for summing values, so the compiler knows it can make optimizations on that front, while fold has a blackbox closure that needs to be applied at every step. If you need to sum by an initial value, just added in the expression `let my_sum = [1, 2, 3].sum() + 3`.
 
 ## 1.6 Comments: Context, not Clutter

--- a/book/chapter_05.md
+++ b/book/chapter_05.md
@@ -282,9 +282,15 @@ Rust comes with 2 macros to make assertions:
 
 ### 🚨 `assert!` reminders
 * Rust asserts support formatted strings, like the previous examples, those strings will be printed in case of failure, so it is a good practice to add what the actual state was and how it differs from the expected.
-* If you don't care about the exact pattern matching value, using `matches!` combined with `assert!` might be a good alternative.
+* If you don't care about the exact pattern matching value, using `matches!` combined with `assert!` might be a good alternative. Note the message string is an argument to `assert!`, not to `matches!`:
 ```rust
-assert!(matches!(error, MyError::BadInput(_), "Expected `BadInput`, found {error}"));
+assert!(matches!(error, MyError::BadInput(_)), "Expected `BadInput`, found {error}");
+```
+* Since Rust 1.96 prefer the stabilized [`assert_matches!`](https://doc.rust-lang.org/std/macro.assert_matches.html) (and [`debug_assert_matches!`](https://doc.rust-lang.org/std/macro.debug_assert_matches.html)) over `assert!(matches!(..))`. It prints the actual value on failure for free, so you don't have to write the message yourself:
+```rust
+use std::assert_matches::assert_matches;
+
+assert_matches!(error, MyError::BadInput(_));
 ```
 * Use `#[should_panic]` wisely. It should only be used when panic is the desired behavior, prefer result instead of panic.
 * There are some other that can enhance your testing experience like:


### PR DESCRIPTION
Rust 1.96 introduced the new `core::range` types and pointed out that implementing both `Copy` and `Iterator` on the same type can be risky. So, we updated the handbook to reflect this. Chapter 1 now includes a warning against using `Copy` and `Iterator` together. It covers both the guidance on which structs should be `Copy` and the iterator anti-patterns, explaining why this can lead to incorrect results. It also explains why the standard library moved the new range types to `IntoIterator`. In Chapter 5, we added the newly stabilized `assert_matches!` and `debug_assert_matches!` as the preferred alternatives to `assert!(matches!(..))`. We also fixed an existing example where the message string was incorrectly placed inside `matches!`, which would have caused it not to compile.