### PR TITLE
chore: update CODEOWNERS to new maintainers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @apollographql/graph-dev
+* @DaleSeo @TylerBloom


### PR DESCRIPTION
The previous maintainers of this repository have all left the company, so the `@apollographql/graph-dev` team doesn't even exit now. So, Dale and Tyler have agreed to take over ownership going forward!