### PR TITLE
docs: add guidance on when not to extract functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ As another source of reference, the Rust Analyzer Style Guide should also be use
     - [Iterator, `.iter` vs `for`](https://github.com/apollographql/rust-best-practices/blob/main/book/chapter_01.md#15-iterator-iter-vs-for)
     - [Comments: Context, not Clutter](https://github.com/apollographql/rust-best-practices/blob/main/book/chapter_01.md#16-comments-context-not-clutter)
     - [Use Declarations - "imports"](https://github.com/apollographql/rust-best-practices/blob/main/book/chapter_01.md#17-use-declarations---imports)
+    - [When to Extract a Function (and When Not To)](https://github.com/apollographql/rust-best-practices/blob/main/book/chapter_01.md#18-when-to-extract-a-function-and-when-not-to)
 - [Chapter 2 - Clippy and Linting Discipline](https://github.com/apollographql/rust-best-practices/blob/main/book/chapter_02.md)
     - [Why care about linting?](https://github.com/apollographql/rust-best-practices/blob/main/book/chapter_02.md#21-why-care-about-linting)
     - [Always run `cargo clippy`](https://github.com/apollographql/rust-best-practices/blob/main/book/chapter_02.md#22-always-run-cargo-clippy)

--- a/book/chapter_01.md
+++ b/book/chapter_01.md
@@ -583,6 +583,10 @@ Two occurrences of a couple of lines are usually **fine**. Wait for the third be
 
 [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) (*The Pragmatic Programmer*) says every piece of **knowledge** should have a single representation. It does **not** say "no two code fragments may look alike". Two blocks that *happen* to look the same today, but represent **different decisions**, will evolve in different directions. Forcing them into one helper couples code that should be free to diverge — this is **coincidental duplication**, and deduplicating it is how wrong abstractions are born.
 
+### 🧪 Examples
+
+How these principles play out in code:
+
 #### ✅ Coincidental duplication — leave it inline:
 ```rust
 // Similar-looking lines, but the `.env` and `.toml` formats are
@@ -604,7 +608,7 @@ fn write_entry(out: &mut impl Write, key: &str, value: &str, quoted: bool) -> io
 }
 ```
 
-Every new variant will grow another parameter or branch. If you find an abstraction like this, [Sandi Metz's advice](https://sandimetz.com/blog/2016/1/20/the-wrong-abstraction) is to **re-inline the helper into its callers**, let the duplication reappear, and only then re-derive the right abstraction — if one exists at all.
+Every new variant will grow another parameter or branch. And the `bool` is a smell in its own right: `write_entry(out, key, value, true)` tells the reader nothing at the call site — Martin Fowler calls this a [Flag Argument](https://martinfowler.com/bliki/FlagArgument.html). When a mode selector is genuinely warranted, a two-variant enum (`Quoting::Quoted`) keeps call sites readable, and Clippy's [`fn_params_excessive_bools`](https://rust-lang.github.io/rust-clippy/master/index.html#fn_params_excessive_bools) lints against accumulating them. No enum rescues *this* design, though: its variants would exist only to encode the callers' differences.
 
 #### ✅ Shared knowledge — extract it:
 ```rust
@@ -614,6 +618,17 @@ fn is_retryable(status: StatusCode) -> bool {
     status == StatusCode::TOO_MANY_REQUESTS || status.is_server_error()
 }
 ```
+
+### 🔧 Unwinding a wrong abstraction
+
+If you find yourself maintaining an abstraction like `write_entry`, [Sandi Metz's advice](https://sandimetz.com/blog/2016/1/20/the-wrong-abstraction) is to **unwind it, not patch it**:
+
+1. **Re-inline** the helper's body into every caller, substituting each call site's concrete arguments.
+2. **Reduce** each call site — with the parameters now literal, dead branches and unused generality fall away.
+3. **Reevaluate** what the callers *actually* share, now that every one of them is explicit.
+4. **Reconstruct** one or more abstractions from what remains — or none, if the sharing turns out to be coincidental.
+
+> 🤖 Doing this by hand is tedious, which is why wrong abstractions survive on sunk cost. For an AI coding agent, unwinding is fast, mechanical work — ask for it explicitly instead of letting the agent keep patching a helper that fights back.
 
 ### ✅ Extract a function when:
 * The logic appears in **3+ places** *and* represents the **same decision** (Rule of Three).

--- a/book/chapter_01.md
+++ b/book/chapter_01.md
@@ -471,6 +471,8 @@ mod tests {
 
 Let **structure** and **naming** replace commentary, and enhance its documentation with **tests as living documentation**.
 
+> ❗ Splitting is about **naming and clarity**, not deduplication. Before extracting a helper to remove *duplicated* lines, check [§1.8](#18-when-to-extract-a-function-and-when-not-to).
+
 ### 📝 TODOs are not comments - track them properly
 
 Avoid leaving lingering `// TODO: Lorem Ipsum` comments in the code. Instead:
@@ -562,3 +564,67 @@ group_imports = "StdExternalCrate"
 ```
 
 > As of Rust version 1.88, it is necessary to execute rustfmt in nightly to correctly reorder code `cargo +nightly fmt`.
+
+## 1.8 When to Extract a Function (and When Not To)
+
+This chapter ([§1.6](#-breaking-up-long-functions-over-commenting-them)) and [Chapter 8](chapter_08.md#85-replace-comments-with-code) recommend splitting long functions and replacing narrative comments with named helpers. That advice is about **naming and clarity** — it is *not* a license to hunt down every repeated line. Extraction has a cost: every helper adds indirection, and a **wrong abstraction is much harder to remove than a little duplication**.
+
+> "Duplication is far cheaper than the wrong abstraction." — [Sandi Metz, The Wrong Abstraction](https://sandimetz.com/blog/2016/1/20/the-wrong-abstraction)
+
+### 📏 The Rule of Three
+
+From [Martin Fowler's *Refactoring*](https://martinfowler.com/books/refactoring.html), attributed to Don Roberts:
+
+> The first time you do something, you just do it. The second time you do something similar, you wince at the duplication, but you do the duplicate thing anyway. The third time you do something similar, you refactor.
+
+Two occurrences of a couple of lines are usually **fine**. Wait for the third before reaching for a helper — by then you will know what the abstraction actually *is*, instead of guessing at it.
+
+### 🧠 DRY is about knowledge, not text
+
+[DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) (*The Pragmatic Programmer*) says every piece of **knowledge** should have a single representation. It does **not** say "no two code fragments may look alike". Two blocks that *happen* to look the same today, but represent **different decisions**, will evolve in different directions. Forcing them into one helper couples code that should be free to diverge — this is **coincidental duplication**, and deduplicating it is how wrong abstractions are born.
+
+#### ✅ Coincidental duplication — leave it inline:
+```rust
+// Similar-looking lines, but the `.env` and `.toml` formats are
+// unrelated decisions that will evolve independently:
+writeln!(env_file, "{key}={value}")?;
+// ... elsewhere ...
+writeln!(toml_file, "{key} = \"{value}\"")?;
+```
+
+#### ❌ Deduplicating it forces a flag parameter — the classic smell:
+```rust
+// One helper, two behaviors, and a `bool` to pick between them:
+fn write_entry(out: &mut impl Write, key: &str, value: &str, quoted: bool) -> io::Result<()> {
+    if quoted {
+        writeln!(out, "{key} = \"{value}\"")
+    } else {
+        writeln!(out, "{key}={value}")
+    }
+}
+```
+
+Every new variant will grow another parameter or branch. If you find an abstraction like this, [Sandi Metz's advice](https://sandimetz.com/blog/2016/1/20/the-wrong-abstraction) is to **re-inline the helper into its callers**, let the duplication reappear, and only then re-derive the right abstraction — if one exists at all.
+
+#### ✅ Shared knowledge — extract it:
+```rust
+// The definition of "retryable" is ONE business decision used in many
+// places. If it changes, it must change everywhere at once:
+fn is_retryable(status: StatusCode) -> bool {
+    status == StatusCode::TOO_MANY_REQUESTS || status.is_server_error()
+}
+```
+
+### ✅ Extract a function when:
+* The logic appears in **3+ places** *and* represents the **same decision** (Rule of Three).
+* The name **adds meaning** the code alone does not (`is_retryable`, `authorize`) — rather than restating it (`add_one_to_counter`).
+* It produces a **unit worth testing** in isolation (see [§1.6](#-breaking-up-long-functions-over-commenting-them)).
+* It hides genuine complexity behind a **small, honest signature** — few parameters, no flags.
+
+### ❌ Don't extract when:
+* It is **1–2 lines used in fewer than 3 places** — the helper is pure indirection.
+* The call sites are only *almost* identical, and unifying them requires **flag parameters** or extra branches.
+* The only motivation is **line count**. A single-caller helper pays off when its *name* clarifies intent ([§1.6](#-breaking-up-long-functions-over-commenting-them), [§8.5](chapter_08.md#85-replace-comments-with-code)) — not when it merely relocates code.
+* You are **guessing** at a future abstraction. Wait for the third usage to reveal its real shape.
+
+> 🚨 When in doubt, **prefer duplication**. A duplicated line is trivially fixed later; a wrong abstraction accretes parameters and conditionals, because each maintainer keeps patching it instead of undoing it.

--- a/book/chapter_01.md
+++ b/book/chapter_01.md
@@ -642,4 +642,16 @@ If you find yourself maintaining an abstraction like `write_entry`, [Sandi Metz'
 * The only motivation is **line count**. A single-caller helper pays off when its *name* clarifies intent ([§1.6](#-breaking-up-long-functions-over-commenting-them), [§8.5](chapter_08.md#85-replace-comments-with-code)) — not when it merely relocates code.
 * You are **guessing** at a future abstraction. Wait for the third usage to reveal its real shape.
 
+### 🧫 Test code: readability beats DRY
+
+In tests, be **even more tolerant of duplication**. The Google Testing Blog calls this [DAMP — "Descriptive And Meaningful Phrases"](https://testing.googleblog.com/2019/12/testing-on-toilet-tests-too-dry-make.html) ([*Software Engineering at Google*, ch. 12](https://abseil.io/resources/swe-book/html/ch12.html)): each test should read as a **self-contained story** — setup, action, assertion — without the reader chasing helpers to reconstruct what actually happened.
+
+* **Tests have no tests.** Logic moved into a shared helper (loops, branches, clever parametrization) is itself untested — a bug there silently weakens every test built on it.
+* **A failing test should be diagnosable on sight.** The reader is usually debugging a broken build; make the expected behavior visible in the test body, not three helpers away.
+* **Shared test helpers couple unrelated tests.** Change one behavior and dozens of tests fail at once — for the helper's sake, not the behavior's.
+
+Where to draw the line:
+* ✅ Share **setup and fixtures** — a shared setup function or `rstest` cases, as [Chapter 5](chapter_05.md#51-tests-as-living-documentation) recommends. Constructing a test server twice is boilerplate, not knowledge.
+* ❌ Keep each test's **action and assertion inline**, even when they look repetitive across tests.
+
 > 🚨 When in doubt, **prefer duplication**. A duplicated line is trivially fixed later; a wrong abstraction accretes parameters and conditionals, because each maintainer keeps patching it instead of undoing it.

--- a/book/chapter_05.md
+++ b/book/chapter_05.md
@@ -174,6 +174,8 @@ fn the_function_accepts_all_strings_with_a(#[case] input: &str) {
 > * It’s harder for both IDEs and humans to run/locate specific tests.
 > * Expectation vs condition naming is now visually inverted (expectation first).
 
+> ❗ Share **setup**, not the test itself: keep each test's action and assertion inline, even when repetitive. Tests tolerate duplication better than production code — see [Chapter 1, §1.8](chapter_01.md#-test-code-readability-beats-dry).
+
 ## 5.2 Add Test Examples to your Docs
 
 We will deep dive into docs at a later stage, so in this section we will just briefly go over how to add tests to you docs. Rustdoc can turn examples into executable tests using `///` with a few advantages:

--- a/book/chapter_08.md
+++ b/book/chapter_08.md
@@ -103,6 +103,8 @@ fn save_auth_user(&self) -> Result<PathBuf, MyError> {
 }
 ```
 
+> ❗ Extract when the **name adds meaning** — not to deduplicate a couple of similar-looking lines. See [Chapter 1, §1.8](chapter_01.md#18-when-to-extract-a-function-and-when-not-to) for when duplication is the better trade-off.
+
 ## 8.6 `TODO` should become issues
 
 Don't leave `// TODO:` scattered around the codebase with no owner. Instead:


### PR DESCRIPTION
We've gotten some feedback from teams using this handbook to guide AI coding agents with [the rust-best-practices skill](https://www.skills.sh/apollographql/skills/rust-best-practices). They noted that the agents often over-extract, like turning one-liner duplications into helpers or deduplicating code that only appears twice. Right now, the handbook only pushes in one direction. Sections 1.6 and 8.5 both say to "split into smaller functions" without any balance.

So, this PR adds a new section, 1.8, that discusses the Rule of Three (Fowler/Roberts), the idea that "duplication is far cheaper than the wrong abstraction" (Sandi Metz), and the knowledge-vs-text interpretation of DRY. This will include ✅/❌ Rust examples, like the flag-parameter smell. We'll also add brief cross-references in sections 1.6 and 8.5 that point to the new section.